### PR TITLE
Checks that `onPressCalendar` is a function before calling it

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-calendar",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "license": "MIT",
   "author": "Adalo",
   "description": "Display a list of events on a calendar.  Also includes option for an agenda view.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-calendar",
-  "version": "1.2.5",
+  "version": "1.2.7",
   "license": "MIT",
   "author": "Adalo",
   "description": "Display a list of events on a calendar.  Also includes option for an agenda view.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-calendar",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "license": "MIT",
   "author": "Adalo",
   "description": "Display a list of events on a calendar.  Also includes option for an agenda view.",

--- a/src/components/DynamicCalendar/index.js
+++ b/src/components/DynamicCalendar/index.js
@@ -55,7 +55,7 @@ class DynamicCalendar extends Component {
           id = this.state.agendaEvents[i].id
         }
       }
-      let { onPressCalendar } = this.props.items[Number(id)]
+      let { onPressCalendar } = this.props.items[Number(id)] || {}
       if (onPressCalendar && typeof onPressCalendar === 'function') {
         onPressCalendar()
       }

--- a/src/components/DynamicCalendar/index.js
+++ b/src/components/DynamicCalendar/index.js
@@ -56,7 +56,9 @@ class DynamicCalendar extends Component {
         }
       }
       let { onPressCalendar } = this.props.items[Number(id)]
-      onPressCalendar && onPressCalendar()
+      if (onPressCalendar && typeof onPressCalendar === 'function') {
+        onPressCalendar()
+      }
     } else {
       this.setState({ calendarRender: !this.state.calendarRender })
     }

--- a/src/components/DynamicCalendar/index.js
+++ b/src/components/DynamicCalendar/index.js
@@ -46,16 +46,12 @@ class DynamicCalendar extends Component {
       this.setState({ goBackTrigger: true })
       let passDate = new Date(day.dateString)
       passDate.setDate(passDate.getDate() + 1)
-      let id
-      for (let i = 0; i < this.state.agendaEvents.length; ++i) {
-        if (
-          this.formatDate(new Date(this.state.agendaEvents[i].start), false) ==
-          this.formatDate(new Date(passDate), false)
-        ) {
-          id = this.state.agendaEvents[i].id
-        }
-      }
-      let { onPressCalendar } = this.props.items[Number(id)] || {}
+      let event = this.state.agendaEvents.filter((event) =>
+        event.start.includes(day.dateString)
+      )[0]
+      let id = event ? event.id : null
+      if (!id && id !== 0) return
+      let { onPressCalendar } = this.props.items[Number(id)]
       if (onPressCalendar && typeof onPressCalendar === 'function') {
         onPressCalendar()
       }


### PR DESCRIPTION
## Problem
For some reason in rare cases `onPressCalendar` is not a function but is still defined. This likely has to do with the issue Paulo found a week or so ago that was similar.

Followup: Turns out the filtering function Akshat wrote to figure out which date was pressed was faulty. Not sure what exactly was wrong but I rewrote the logic using javascript's `filter` function and it now works as intended.

## Solution
Check that `onPressCalendar` actually is a function before calling it.

Followup: rewrote the filtering inside `onDayPress`

## Notes
I couldn't reproduce this issue 100% of the time, but the code can't hurt...