### PR TITLE
Bump react-native-calendars package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-calendar",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "license": "MIT",
   "author": "Adalo",
   "description": "Display a list of events on a calendar.  Also includes option for an agenda view.",
@@ -46,7 +46,7 @@
     "moment": "^2.26.0",
     "react-native-calendar-events": "^1.7.3",
     "react-native-calendar-strip": "^2.0.1",
-    "react-native-calendars": "^1.1247.0",
+    "react-native-calendars": "1.1260.0",
     "react-native-event-calendar-customized": "^1.0.19",
     "react-native-events-calendar": "git+https://github.com/joshjhargreaves/react-native-event-calendar.git",
     "react-native-vector-icons": "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4959,18 +4959,19 @@ react-native-calendar-strip@^2.0.1:
     prop-types "^15.6.0"
     recyclerlistview "^3.0.0"
 
-react-native-calendars@^1.1247.0:
-  version "1.1247.0"
-  resolved "https://registry.yarnpkg.com/react-native-calendars/-/react-native-calendars-1.1247.0.tgz#63af7dcafbddffc9fedc5af4717c10ae48e637af"
-  integrity sha512-7N1IHN3uGFFGK4zjz1WhDWhfl0ofzapxFkNTTUhid76YJu9/YHs1hp2X21pBHGtnxdhP68/U8b7b8X9/xAubjA==
+react-native-calendars@1.1260.0:
+  version "1.1260.0"
+  resolved "https://registry.yarnpkg.com/react-native-calendars/-/react-native-calendars-1.1260.0.tgz#1dd4f5108acc414555059be2f58b61caf9a65c10"
+  integrity sha512-LOM8Jb9RGSv/qwAnuj55ijgsiC5uGFnlLIyE4GyEMoW212qIjTaNIgGR5kLQQmJ8cfh7vBpuDPKy17Io4Ar/4A==
   dependencies:
     hoist-non-react-statics "^3.3.1"
     immutable "^4.0.0-rc.12"
     lodash "^4.17.15"
-    moment "^2.24.0"
     prop-types "^15.5.10"
     react-native-swipe-gestures "^1.0.5"
     xdate "^0.8.0"
+  optionalDependencies:
+    moment "^2.24.0"
 
 react-native-event-calendar-customized@^1.0.19:
   version "1.0.19"


### PR DESCRIPTION
Version `1.1247` of `react-native-calendars` was causing build failures. Version `1.1260.0` fixes it.