### PR TITLE
Bugfix: Cannot read property 'agenda' of undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-calendar",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "license": "MIT",
   "author": "Adalo",
   "description": "Display a list of events on a calendar.  Also includes option for an agenda view.",

--- a/src/components/DynamicCalendar/index.js
+++ b/src/components/DynamicCalendar/index.js
@@ -31,7 +31,7 @@ class DynamicCalendar extends Component {
     const { items } = this.props
     const { items: prevItems } = prevProps
     if (items[0]?.agenda.timeFormat !== prevItems[0]?.agenda.timeFormat) {
-      this.setState({ timeFormat: items[0].agenda.timeFormat })
+      this.setState({ timeFormat: items[0]?.agenda.timeFormat || 0 })
     }
   }
 
@@ -216,13 +216,8 @@ class DynamicCalendar extends Component {
           }
 
     // colors
-    let {
-      activeColor,
-      textColor,
-      disabledColor,
-      bgColor,
-      headingTextColor,
-    } = colors
+    let { activeColor, textColor, disabledColor, bgColor, headingTextColor } =
+      colors
     // navigation
     let { defDate, minDate, maxDate, changeMonths } = navigation
     if (maxDate === '2021-01-01') {


### PR DESCRIPTION
## Problem
When the component is unmounted, the `items` variable was an empty list, and when we try to access the `agenda` property of your `0` position, the error occours.

## Solution
Check if the `items[0]` isn't undefined or null, and if it was, set the `timeFormat` to your default value: `0`.