### PR TITLE
Set height explicitly for calendar events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-calendar",
-  "version": "1.3.15",
+  "version": "1.3.16",
   "license": "MIT",
   "author": "Adalo",
   "description": "Display a list of events on a calendar.  Also includes option for an agenda view.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-calendar",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "license": "MIT",
   "author": "Adalo",
   "description": "Display a list of events on a calendar.  Also includes option for an agenda view.",

--- a/src/components/DynamicCalendar/eventCal/DayView.js
+++ b/src/components/DynamicCalendar/eventCal/DayView.js
@@ -199,12 +199,14 @@ export default class DayView extends React.PureComponent {
 
   render() {
     const { styles } = this.props
+    const PACKED_EVENTS_CONTAINER_HEIGHT = 380
+
     return (
       <ScrollView
         ref={(ref) => (this._scrollView = ref)}
         contentContainerStyle={[
           styles.contentStyle,
-          { width: this.props.width },
+          { width: this.props.width, height: PACKED_EVENTS_CONTAINER_HEIGHT },
         ]}
       >
         {this._renderLines()}

--- a/src/components/DynamicCalendar/eventCal/DayView.js
+++ b/src/components/DynamicCalendar/eventCal/DayView.js
@@ -199,7 +199,7 @@ export default class DayView extends React.PureComponent {
 
   render() {
     const { styles, height, marginTop } = this.props
-    const PACKED_EVENTS_CONTAINER_HEIGHT = height -  styles?.header?.height - marginTop
+    const PACKED_EVENTS_CONTAINER_HEIGHT = height -  (styles?.header?.height) || 0 - marginTop
 
     return (
       <ScrollView

--- a/src/components/DynamicCalendar/eventCal/DayView.js
+++ b/src/components/DynamicCalendar/eventCal/DayView.js
@@ -199,7 +199,7 @@ export default class DayView extends React.PureComponent {
 
   render() {
     const { styles, height, marginTop } = this.props
-    const PACKED_EVENTS_CONTAINER_HEIGHT = height -  (styles?.header?.height) || 0 - marginTop
+    const PACKED_EVENTS_CONTAINER_HEIGHT = height -  ((styles?.header?.height) || 0) - marginTop
 
     return (
       <ScrollView

--- a/src/components/DynamicCalendar/eventCal/DayView.js
+++ b/src/components/DynamicCalendar/eventCal/DayView.js
@@ -198,8 +198,8 @@ export default class DayView extends React.PureComponent {
   }
 
   render() {
-    const { styles } = this.props
-    const PACKED_EVENTS_CONTAINER_HEIGHT = 380
+    const { styles, height, marginTop } = this.props
+    const PACKED_EVENTS_CONTAINER_HEIGHT = height -  styles?.header?.height - marginTop
 
     return (
       <ScrollView

--- a/src/components/DynamicCalendar/eventCal/EventCalendar.js
+++ b/src/components/DynamicCalendar/eventCal/EventCalendar.js
@@ -86,6 +86,8 @@ export default class EventCalendar extends React.Component {
   _renderItem({ index, item }) {
     const {
       width,
+      _height,
+      marginTop,
       format24h,
       initDate,
       scrollToFirst = true,
@@ -129,6 +131,8 @@ export default class EventCalendar extends React.Component {
           eventTapped={this.props.eventTapped}
           events={item}
           width={width}
+          height={_height}
+          marginTop={marginTop}
           styles={this.styles}
           scrollToFirst={scrollToFirst}
           start={start}

--- a/src/components/DynamicCalendar/index.js
+++ b/src/components/DynamicCalendar/index.js
@@ -369,9 +369,11 @@ class DynamicCalendar extends Component {
       }
     }
 
+    const CALENDAR_MARGIN_TOP = 20
+
     if (!(editor && agendaRenderPass) && this.state.calendarRender) {
       return (
-        <View style={{ flex: 1, marginTop: 20 }}>
+        <View style={{ flex: 1, marginTop: CALENDAR_MARGIN_TOP }}>
           <Calendar
             key={`${activeColor}${textColor}${disabledColor}${bgColor}${headingTextColor}${_height}`}
             theme={{
@@ -441,7 +443,7 @@ class DynamicCalendar extends Component {
     }
 
     return (
-      <View style={{ flex: 1, marginTop: 20 }}>
+      <View style={{ flex: 1, marginTop: CALENDAR_MARGIN_TOP }}>
         <EventCalendar
           {...this.props}
           title={passedTitle}
@@ -459,6 +461,7 @@ class DynamicCalendar extends Component {
           initDate={this.state.chosenDay}
           scrollToFirst
           format24h={timeFormat}
+          marginTop={CALENDAR_MARGIN_TOP}
         />
       </View>
     )


### PR DESCRIPTION
Add a height explicitly for calendar events, currently we have this ratio between the calendar header and it's events for a give nday

Header:

![image](https://github.com/AdaloHQ/calendar/assets/4576630/d1a2a92f-56c5-4f27-8d00-7cd8e35715d8)

Events:

![image](https://github.com/AdaloHQ/calendar/assets/4576630/51e67ef8-58f8-4c12-81d0-8ad1d4f8de59)

So I set a height of 380 (430 - 50)

The good thing is that this also solves the issue when responsive apps have their calendar to extend the entire screen instead of being constrained into the scrollview container:



https://github.com/AdaloHQ/calendar/assets/4576630/646dbbac-097c-4325-9105-78909ec157ea

