### PR TITLE
Fix Calendar Day View Scrolling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-calendar",
-  "version": "1.3.23",
+  "version": "1.3.24",
   "license": "MIT",
   "author": "Adalo",
   "description": "Display a list of events on a calendar.  Also includes option for an agenda view.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-calendar",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "license": "MIT",
   "author": "Adalo",
   "description": "Display a list of events on a calendar.  Also includes option for an agenda view.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-calendar",
-  "version": "1.3.22",
+  "version": "1.3.23",
   "license": "MIT",
   "author": "Adalo",
   "description": "Display a list of events on a calendar.  Also includes option for an agenda view.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-calendar",
-  "version": "1.3.17",
+  "version": "1.3.18",
   "license": "MIT",
   "author": "Adalo",
   "description": "Display a list of events on a calendar.  Also includes option for an agenda view.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-calendar",
-  "version": "1.3.18",
+  "version": "1.3.20",
   "license": "MIT",
   "author": "Adalo",
   "description": "Display a list of events on a calendar.  Also includes option for an agenda view.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-calendar",
-  "version": "1.3.20",
+  "version": "1.3.21",
   "license": "MIT",
   "author": "Adalo",
   "description": "Display a list of events on a calendar.  Also includes option for an agenda view.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-calendar",
-  "version": "1.3.21",
+  "version": "1.3.22",
   "license": "MIT",
   "author": "Adalo",
   "description": "Display a list of events on a calendar.  Also includes option for an agenda view.",

--- a/src/components/DynamicCalendar/eventCal/DayView.js
+++ b/src/components/DynamicCalendar/eventCal/DayView.js
@@ -201,7 +201,7 @@ export default class DayView extends React.PureComponent {
     const { styles, height, marginTop } = this.props
     const PACKED_EVENTS_CONTAINER_HEIGHT = height -  ((styles?.header?.height) || 0) - marginTop
 
-    console.log('AVOHAI', PACKED_EVENTS_CONTAINER_HEIGHT)
+    const CALENDAR_PADDING = 100
 
     return (
       <SafeAreaView style={{ height: PACKED_EVENTS_CONTAINER_HEIGHT }}>
@@ -209,7 +209,10 @@ export default class DayView extends React.PureComponent {
           ref={(ref) => (this._scrollView = ref)}
           contentContainerStyle={[
             styles.contentStyle,
-            { width: this.props.width, height: this.calendarHeight + 100 },
+            {
+              width: this.props.width,
+              height: this.calendarHeight + CALENDAR_PADDING
+            },
           ]}
         >
         {this._renderLines()}

--- a/src/components/DynamicCalendar/eventCal/DayView.js
+++ b/src/components/DynamicCalendar/eventCal/DayView.js
@@ -43,7 +43,7 @@ export default class DayView extends React.PureComponent {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const width = nextProps.width - LEFT_MARGIN
 
     if (nextProps.events.length === 1 && Object.keys(nextProps.events[0]).length === 0) {

--- a/src/components/DynamicCalendar/eventCal/DayView.js
+++ b/src/components/DynamicCalendar/eventCal/DayView.js
@@ -42,6 +42,7 @@ export default class DayView extends React.PureComponent {
 
   componentDidMount() {
     this.props.scrollToFirst && this.scrollToFirst()
+    this.props._setScrollEnabled && this.props._setScrollEnabled(false)
   }
 
   scrollToFirst() {

--- a/src/components/DynamicCalendar/eventCal/DayView.js
+++ b/src/components/DynamicCalendar/eventCal/DayView.js
@@ -22,7 +22,18 @@ export default class DayView extends React.PureComponent {
     super(props)
     this.calendarHeight = (props.end - props.start) * 100
     const width = props.width - LEFT_MARGIN
+    const events = props.events
+
+    if (events.length === 1 && Object.keys(events[0]).length === 0) {
+      this.state = {
+        _scrollY: 0,
+        packedEvents: [],
+      }
+      return
+    }
+
     const packedEvents = populateEvents(props.events, width, props.start)
+    console.log('packedEvents', packedEvents, props.events)
     let initPosition =
       _.min(_.map(packedEvents, 'top')) -
       this.calendarHeight / (props.end - props.start)
@@ -35,6 +46,14 @@ export default class DayView extends React.PureComponent {
 
   componentWillReceiveProps(nextProps) {
     const width = nextProps.width - LEFT_MARGIN
+
+    if (nextProps.events.length === 1 && Object.keys(nextProps.events[0]).length === 0) {
+      this.setState({
+        packedEvents: [],
+      })
+      return
+    }
+
     this.setState({
       packedEvents: populateEvents(nextProps.events, width, nextProps.start),
     })

--- a/src/components/DynamicCalendar/eventCal/DayView.js
+++ b/src/components/DynamicCalendar/eventCal/DayView.js
@@ -1,5 +1,5 @@
 // @flow
-import { View, Text, ScrollView, TouchableOpacity } from 'react-native'
+import { View, Text, ScrollView, SafeAreaView, TouchableOpacity } from 'react-native'
 import React from 'react'
 import moment from 'moment'
 import _ from 'lodash'
@@ -201,18 +201,22 @@ export default class DayView extends React.PureComponent {
     const { styles, height, marginTop } = this.props
     const PACKED_EVENTS_CONTAINER_HEIGHT = height -  ((styles?.header?.height) || 0) - marginTop
 
+    console.log('AVOHAI', PACKED_EVENTS_CONTAINER_HEIGHT)
+
     return (
-      <ScrollView
-        ref={(ref) => (this._scrollView = ref)}
-        contentContainerStyle={[
-          styles.contentStyle,
-          { width: this.props.width, height: PACKED_EVENTS_CONTAINER_HEIGHT },
-        ]}
-      >
+      <SafeAreaView style={{ height: PACKED_EVENTS_CONTAINER_HEIGHT }}>
+        <ScrollView
+          ref={(ref) => (this._scrollView = ref)}
+          contentContainerStyle={[
+            styles.contentStyle,
+            { width: this.props.width, height: this.calendarHeight + 100 },
+          ]}
+        >
         {this._renderLines()}
         {this._renderEvents()}
         {/* {this._renderRedLine()} */}
       </ScrollView>
+      </SafeAreaView>
     )
   }
 }

--- a/src/components/DynamicCalendar/eventCal/DayView.js
+++ b/src/components/DynamicCalendar/eventCal/DayView.js
@@ -33,7 +33,6 @@ export default class DayView extends React.PureComponent {
     }
 
     const packedEvents = populateEvents(props.events, width, props.start)
-    console.log('packedEvents', packedEvents, props.events)
     let initPosition =
       _.min(_.map(packedEvents, 'top')) -
       this.calendarHeight / (props.end - props.start)

--- a/src/components/DynamicCalendar/eventCal/EventCalendar.js
+++ b/src/components/DynamicCalendar/eventCal/EventCalendar.js
@@ -1,6 +1,7 @@
 // @flow
 import {
   VirtualizedList,
+  FlatList,
   View,
   TouchableOpacity,
   Image,
@@ -64,6 +65,11 @@ export default class EventCalendar extends React.Component {
     size: 30,
     initDate: new Date(),
     formatHeader: 'DD MMMM YYYY',
+  }
+
+  _getItemLayout(data, index) {
+    const { width } = this.props
+    return { length: width, offset: width * index, index }
   }
 
   _getItem(events, index) {
@@ -169,27 +175,53 @@ export default class EventCalendar extends React.Component {
   }
 
   render() {
-    const { width, virtualizedListProps, events, initDate } = this.props
+    const { width, virtualizedListProps, flatListProps, events, initDate } = this.props
+
+    console.log('how many events', events)
 
     return (
       <View style={[this.styles.container, { width }]}>
-        <VirtualizedList
-          scrollEnabled={false}
-          ref={this.calendarRef}
-          windowSize={2}
-          initialNumToRender={2}
-          initialScrollIndex={this.props.size}
+        {/* <VirtualizedList */}
+        {/*   scrollEnabled={false} */}
+        {/*   ref={this.calendarRef} */}
+        {/*   windowSize={2} */}
+        {/*   initialNumToRender={2} */}
+        {/*   initialScrollIndex={this.props.size} */}
+        {/*   data={events} */}
+        {/*   getItemCount={() => this.props.size * 2} */}
+        {/*   getItem={this._getItem.bind(this)} */}
+        {/*   keyExtractor={(item, index) => index.toString()} */}
+        {/*   getItemLayout={this._getItemLayout.bind(this)} */}
+        {/*   horizontal */}
+        {/*   pagingEnabled */}
+        {/*   renderItem={this._renderItem.bind(this)} */}
+        {/*   style={{ width: width }} */}
+        {/*   onMomentumScrollEnd={(event) => { */}
+        {/*     const index = parseInt(event.nativeEvent.contentOffset.x / width) */}
+        {/*     const date = moment(initDate).add( */}
+        {/*       index - this.props.size, */}
+        {/*       'days' */}
+        {/*     ) */}
+        {/*     if (this.props.dateChanged) { */}
+        {/*       this.props.dateChanged(date.format('YYYY-MM-DD')) */}
+        {/*     } */}
+        {/*     this.setState({ index, date }) */}
+        {/*   }} */}
+        {/*   {...virtualizedListProps} */}
+        {/* /> */}
+
+        <FlatList
+
           data={events}
-          getItemCount={() => this.props.size * 2}
-          getItem={this._getItem.bind(this)}
-          keyExtractor={(item, index) => index.toString()}
           horizontal
           pagingEnabled
-          renderItem={this._renderItem.bind(this)}
-          style={{ width: width }}
+          keyExtractor={(item, index) => index.toString()}
+          renderItem={({ item, index }) => this._renderItem({ item: [item], index })}
+          initialScrollIndex={this.props.size}
+          getItemLayout={this._getItemLayout.bind(this)}
           onMomentumScrollEnd={(event) => {
             const index = parseInt(event.nativeEvent.contentOffset.x / width)
-            const date = moment(this.props.initDate).add(
+            const date = moment(initDate).add(
               index - this.props.size,
               'days'
             )
@@ -198,7 +230,7 @@ export default class EventCalendar extends React.Component {
             }
             this.setState({ index, date })
           }}
-          {...virtualizedListProps}
+          {...flatListProps} // Additional FlatList props
         />
       </View>
     )

--- a/src/components/DynamicCalendar/eventCal/EventCalendar.js
+++ b/src/components/DynamicCalendar/eventCal/EventCalendar.js
@@ -131,6 +131,7 @@ export default class EventCalendar extends React.Component {
           headerStyle={this.props.headerStyle}
           renderEvent={this.props.renderEvent}
           eventTapped={this.props.eventTapped}
+          _setScrollEnabled={this.props._setScrollEnabled}
           events={item}
           width={width}
           height={_height}
@@ -169,6 +170,7 @@ export default class EventCalendar extends React.Component {
 
   _onBackButton() {
     this.props.backButton()
+    this.props._setScrollEnabled && this.props._setScrollEnabled(true)
   }
 
   render() {

--- a/src/components/DynamicCalendar/eventCal/EventCalendar.js
+++ b/src/components/DynamicCalendar/eventCal/EventCalendar.js
@@ -186,7 +186,7 @@ export default class EventCalendar extends React.Component {
       )
     })
 
-    console.log('ALL filtered events', filteredEvents)
+    console.log('filteredEvents please work im tired', filteredEvents)
 
     if(filteredEvents.length === 0) {
       filteredEvents = [{}]
@@ -196,11 +196,11 @@ export default class EventCalendar extends React.Component {
     return (
       <View style={[this.styles.container, { width }]}>
         <FlatList
-          data={filteredEvents}
+          data={[{}]}
           horizontal
           pagingEnabled
-          keyExtractor={(item, index) => index.toString()}
-          renderItem={({ item, index }) => this._renderItem({ item: filteredEvents, index })}
+          keyExtractor={(index) => index.toString()}
+          renderItem={({ index }) => this._renderItem({ item: filteredEvents, index })}
           initialScrollIndex={this.props.size}
           getItemLayout={this._getItemLayout.bind(this)}
           onMomentumScrollEnd={(event) => {

--- a/src/components/DynamicCalendar/eventCal/EventCalendar.js
+++ b/src/components/DynamicCalendar/eventCal/EventCalendar.js
@@ -209,7 +209,6 @@ export default class EventCalendar extends React.Component {
         {/* /> */}
 
         <FlatList
-
           data={events}
           horizontal
           pagingEnabled

--- a/src/components/DynamicCalendar/eventCal/EventCalendar.js
+++ b/src/components/DynamicCalendar/eventCal/EventCalendar.js
@@ -66,11 +66,6 @@ export default class EventCalendar extends React.Component {
     formatHeader: 'DD MMMM YYYY',
   }
 
-  _getItemLayout(data, index) {
-    const { width } = this.props
-    return { length: width, offset: width * index, index }
-  }
-
   _getItem(events, index) {
     const date = moment(this.props.initDate).add(
       index - this.props.size,
@@ -188,7 +183,6 @@ export default class EventCalendar extends React.Component {
           getItemCount={() => this.props.size * 2}
           getItem={this._getItem.bind(this)}
           keyExtractor={(item, index) => index.toString()}
-          getItemLayout={this._getItemLayout.bind(this)}
           horizontal
           pagingEnabled
           renderItem={this._renderItem.bind(this)}

--- a/src/components/DynamicCalendar/eventCal/EventCalendar.js
+++ b/src/components/DynamicCalendar/eventCal/EventCalendar.js
@@ -31,6 +31,8 @@ export default class EventCalendar extends React.Component {
     const start = props.start ? props.start : 0
     const end = props.end ? props.end : 24
 
+    this.calendarRef = React.createRef()
+
     this.styles = styleConstructor(
       props.styles,
       (end - start) * 100,
@@ -150,7 +152,9 @@ export default class EventCalendar extends React.Component {
       index - this.props.size,
       'days'
     )
-    this.refs.calendar.scrollToIndex({ index, animated: false })
+
+    this.calendarRef.current.scrollToIndex({ index, animated: false })
+
     this.setState({ index, date })
   }
 
@@ -174,7 +178,7 @@ export default class EventCalendar extends React.Component {
       <View style={[this.styles.container, { width }]}>
         <VirtualizedList
           scrollEnabled={false}
-          ref="calendar"
+          ref={this.calendarRef}
           windowSize={2}
           initialNumToRender={2}
           initialScrollIndex={this.props.size}

--- a/src/components/DynamicCalendar/eventCal/EventCalendar.js
+++ b/src/components/DynamicCalendar/eventCal/EventCalendar.js
@@ -1,6 +1,5 @@
 // @flow
 import {
-  VirtualizedList,
   FlatList,
   View,
   TouchableOpacity,
@@ -99,7 +98,6 @@ export default class EventCalendar extends React.Component {
       formatHeader,
       upperCaseHeader = false,
     } = this.props
-    console.log('render ONE event', item)
     const date = moment(initDate).add(index - this.props.size, 'days')
 
     const backIcon = this.props.headerBackIcon ? (
@@ -186,8 +184,6 @@ export default class EventCalendar extends React.Component {
       )
     })
 
-    console.log('filteredEvents please work im tired', filteredEvents)
-
     if(filteredEvents.length === 0) {
       filteredEvents = [{}]
     }
@@ -216,34 +212,6 @@ export default class EventCalendar extends React.Component {
           }}
           {...flatListProps}
         />
-        {/* <VirtualizedList */}
-        {/*   scrollEnabled={false} */}
-        {/*   ref={this.calendarRef} */}
-        {/*   windowSize={2} */}
-        {/*   initialNumToRender={2} */}
-        {/*   initialScrollIndex={this.props.size} */}
-        {/*   data={events} */}
-        {/*   getItemCount={() => this.props.size * 2} */}
-        {/*   getItem={this._getItem.bind(this)} */}
-        {/*   keyExtractor={(item, index) => index.toString()} */}
-        {/*   getItemLayout={this._getItemLayout.bind(this)} */}
-        {/*   horizontal */}
-        {/*   pagingEnabled */}
-        {/*   renderItem={this._renderItem.bind(this)} */}
-        {/*   style={{ width: width }} */}
-        {/*   onMomentumScrollEnd={(event) => { */}
-        {/*     const index = parseInt(event.nativeEvent.contentOffset.x / width) */}
-        {/*     const date = moment(initDate).add( */}
-        {/*       index - this.props.size, */}
-        {/*       'days' */}
-        {/*     ) */}
-        {/*     if (this.props.dateChanged) { */}
-        {/*       this.props.dateChanged(date.format('YYYY-MM-DD')) */}
-        {/*     } */}
-        {/*     this.setState({ index, date }) */}
-        {/*   }} */}
-        {/*   {...virtualizedListProps} */}
-        {/* /> */}
       </View>
     )
   }

--- a/src/components/DynamicCalendar/eventCal/EventCalendar.js
+++ b/src/components/DynamicCalendar/eventCal/EventCalendar.js
@@ -177,8 +177,6 @@ export default class EventCalendar extends React.Component {
   render() {
     const { width, virtualizedListProps, flatListProps, events, initDate } = this.props
 
-    console.log('how many events', events)
-
     return (
       <View style={[this.styles.container, { width }]}>
         {/* <VirtualizedList */}

--- a/src/components/DynamicCalendar/index.js
+++ b/src/components/DynamicCalendar/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Dimensions, View } from 'react-native'
+import { View } from 'react-native'
 import { Calendar, LocaleConfig } from 'react-native-calendars'
 import EventCalendar from './eventCal/EventCalendar'
 import * as defaultStyle from './defaultStyles'
@@ -441,8 +441,6 @@ class DynamicCalendar extends Component {
         </View>
       )
     }
-
-    const screenWidth = Dimensions.get('window').width
 
     return (
       <View style={{ flex: 1, marginTop: CALENDAR_MARGIN_TOP }}>

--- a/src/components/DynamicCalendar/index.js
+++ b/src/components/DynamicCalendar/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { View } from 'react-native'
+import { Dimensions, View } from 'react-native'
 import { Calendar, LocaleConfig } from 'react-native-calendars'
 import EventCalendar from './eventCal/EventCalendar'
 import * as defaultStyle from './defaultStyles'
@@ -442,6 +442,8 @@ class DynamicCalendar extends Component {
       )
     }
 
+    const screenWidth = Dimensions.get('window').width
+
     return (
       <View style={{ flex: 1, marginTop: CALENDAR_MARGIN_TOP }}>
         <EventCalendar
@@ -457,7 +459,7 @@ class DynamicCalendar extends Component {
           eventTapped={this.eventTapped}
           backButton={this.goBack}
           events={this.state.agendaEvents}
-          width={this.props._width}
+          width={screenWidth}
           initDate={this.state.chosenDay}
           scrollToFirst
           format24h={timeFormat}

--- a/src/components/DynamicCalendar/index.js
+++ b/src/components/DynamicCalendar/index.js
@@ -459,7 +459,7 @@ class DynamicCalendar extends Component {
           eventTapped={this.eventTapped}
           backButton={this.goBack}
           events={this.state.agendaEvents}
-          width={screenWidth}
+          width={this.props._width}
           initDate={this.state.chosenDay}
           scrollToFirst
           format24h={timeFormat}


### PR DESCRIPTION
## Problem

Previously we pushed changes that prevented the Calendar View (day view) to fill up the entire screen, which is good but with that a new regression was created where in  legacy (ios/android), it affects other platforms as well

## Solution

After trying a few things I found out that I needed to create a [container](https://reactnative.dev/docs/scrollview) where IT has a fixed height and then the scrollable area would have the entire calendar options height (2400). 


After doing that for some reason the scrollable area didn't go till the very end, so I couldn't see the end of it, I setup a deadline for myself and since I couldn't pinpoint what it was (although I noticed similar things happening in previous versions of the component) I added an extra padding 100 (each hour in the screen accounts for 100 so I'm basically adding space for one more hour).

This seem to work across all platforms (ios/android) and targets (responsive/legacy/pwa), the only exception is ios pwa where I can't see any events and instead I see a quick "flash" to what would be the event and then it disappears, it appears that this bug always existed since I can reproduce it even on version 1.0.0.

Video:


https://github.com/AdaloHQ/calendar/assets/4576630/4ca74791-73b4-4195-ab2d-d01502fdf686

